### PR TITLE
place the class into a psr-0 setup so that other modules can 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,10 @@
              "url": "https://github.com/KnpLabs/php-github-api"
          }
     ],
+    "autoload": {
+    "psr-0": {
+            "GithubApi\\": "src/"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/github_api.info
+++ b/github_api.info
@@ -5,5 +5,3 @@ core = 7.x
 
 dependencies[] = composer_manager
 
-files[] = includes/github_api.nativecache.class.inc
-

--- a/github_api.module
+++ b/github_api.module
@@ -57,7 +57,7 @@ function github_api_client($auth = TRUE) {
   $cache_obj = NULL;
   if (variable_get('github_api_use_cache', TRUE)) {
     $cache_obj = new \Github\HttpClient\CachedHttpClient();
-    $cache_obj->setCache(new DrupalGithubApiHttpClientCacheDrupalNativeCache());
+    $cache_obj->setCache(new \GithubApi\DrupalGithubApiHttpClientCacheDrupalNativeCache());
   }
 
   $client = new Github\Client($cache_obj);

--- a/src/GithubApi/DrupalGithubApiHttpClientCacheDrupalNativeCache.php
+++ b/src/GithubApi/DrupalGithubApiHttpClientCacheDrupalNativeCache.php
@@ -1,0 +1,98 @@
+<?php
+namespace GithubApi;
+
+use Github\HttpClient\Cache\CacheInterface,
+    Guzzle\Http\Message\Response;
+
+    /**
+     * Drupal Cache class for Github API.
+     */
+class DrupalGithubApiHttpClientCacheDrupalNativeCache implements CacheInterface {
+
+    /**
+     * @var int
+     * Caches data loaded during cache lookups.
+     */
+    static protected $lookup = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id) {
+        $cached = $this->loadRaw($id);
+        return (bool) $cached;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getModifiedSince($id) {
+        $cached = $this->loadRaw($id);
+        if ($cached) {
+            return $cached['modified_since'];
+        }
+
+        return NULL;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getETag($id) {
+        $cached = $this->loadRaw($id);
+        if ($cached) {
+            return $cached['etag'];
+        }
+
+        return NULL;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id) {
+        $cached = $this->loadRaw($id);
+        if (!$cached) {
+            throw new \InvalidArgumentException("Unable to load {$id}");
+        }
+
+        return $cached['response'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($id, Response $response) {
+        $key = "response_{$id}";
+        $data = array(
+            'response' => $response,
+            'etag' => $response->getHeader('ETag'),
+            'modified_since' => time(),
+        );
+
+        // cache_set can fail silently, so we have no way of knowing if this fails.
+        cache_set($key, $data, 'cache_github_api');
+    }
+
+    /**
+     * Retreieves raw cached objects from the backend.
+     *
+     * @param string $id The id of the cached resource
+     *
+     * @return bool|Guzzle\Http\Message\Response
+     *   Returns FALSE if not found, otherwise the Guzzle response object.
+     */
+    protected function loadRaw($id) {
+        $key = "response_{$id}";
+        if (empty(self::$lookup[$key])) {
+            $cached = cache_get($key, 'cache_github_api');
+            self::$lookup[$id] = $cached;
+        }
+
+        if (!empty(self::$lookup[$key])) {
+            return self::$lookup[$key];
+        }
+
+        return NULL;
+    }
+}


### PR DESCRIPTION
Use psr-0 to extend or include the class

Using

```
use GithubApi\DrupalGithubApiHttpClientCacheDrupalNativeCache;
```

and / or

```
class SomeOtherClass extends DrupalGithubApiHttpClientCacheDrupalNativeCache
```

This way there is a more constant coding standard and not using *.info to include the file.
